### PR TITLE
DPE-781 Run integration tests for passed lint tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
 
   integration-backend:
     name: Integration tests for backend relation
+    needs:
+      - lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,6 +36,8 @@ jobs:
 
   integration-legacy-relations:
     name: Integration tests for legacy relations
+    needs:
+      - lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -48,6 +52,8 @@ jobs:
 
   integration-bundle:
     name: Bundle-specific integration tests
+    needs:
+      - lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.

## Proposal
Decrease tests execution cost in case if lint tests are not happy.

# Context
GitHub Actions.

# Release Notes
Run integration tests for passed lint/unit tests only

# Testing
Check this pull-request tests (GitHub actions) order. Lint tests should go first.