### PR TITLE
Fix PgBouncer series

### DIFF
--- a/releases/latest/postgresql-bundle.yaml
+++ b/releases/latest/postgresql-bundle.yaml
@@ -5,6 +5,7 @@ applications:
     constraints: arch=amd64
     num_units: 1
     revision: 13
+    series: jammy
     to:
     - '1'
   postgresql:
@@ -31,6 +32,7 @@ machines:
     constraints: arch=amd64
   '1':
     constraints: arch=amd64
+    series: jammy
   '2':
     constraints: arch=amd64
 name: postgresql-bundle


### PR DESCRIPTION
## Proposal
Jira issue: [DPE-1027](https://warthogs.atlassian.net/browse/DPE-1027)
The PgBouncer VM charm had its series updated to jammy, but the bundles was not updated yet to work with that.

## Context
Update the bundle to deploy the PgBouncer charm using jammy.

## Release Notes
Update PgBouncer application series to jammy

## Testing
Tested manually and through the existing GitHub CI tests.
