### PR TITLE
Add Alex and Dragomir as reviewers on update PRs

### DIFF
--- a/.github/workflows/on_bundle_update_available.yaml
+++ b/.github/workflows/on_bundle_update_available.yaml
@@ -28,7 +28,7 @@ jobs:
           labels: |
             automated pr
           assignees: team-reviewers,WRFitch,marceloneppel
-          reviewers: team-reviewers,marceloneppel
+          reviewers: team-reviewers,marceloneppel,taurus-forever,dragomirp
           team-reviewers: |
             owners
             maintainers


### PR DESCRIPTION
## Proposal
Add Alex and Dragomir as reviewers on update PRs

## Context
The charms in this bundle are checked once every 8 hours for updates, and if there are updates, it runs tests and opens a PR. 
