### PR TITLE
Add bundle default series

### DIFF
--- a/releases/latest/postgresql-bundle.yaml
+++ b/releases/latest/postgresql-bundle.yaml
@@ -46,4 +46,5 @@ relations:
   - postgresql:database
 - - postgresql:certificates
   - tls-certificates-operator:certificates
+series: focal
 type: bundle


### PR DESCRIPTION
## Issue
After removing the top level `series` field from the bundle file on https://github.com/canonical/postgresql-bundle/commit/fbeae3c3320d6a25e2bc2380af37fd09e1166e70 Charmhub [complains about it](https://github.com/canonical/postgresql-bundle/actions/runs/3648845834/jobs/6264457021).

## Solution
Add the field back to the bundle file.

## Release Notes
Add top level `series` field to the bundle file.

## Testing
No new tests added.
