### PR TITLE
Add workflow status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # PostgreSQL Bundle
+[![Charmhub](https://charmhub.io/postgresql-bundle/badge.svg)](https://charmhub.io/postgresql-bundle)
+[![Release](https://github.com/canonical/postgresql-bundle/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/postgresql-bundle/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/postgresql-bundle/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/postgresql-bundle/actions/workflows/ci.yaml)
 
 A juju bundle for deploying PostgreSQL and PGBouncer machine charms, with TLS enabled by default. For kubernetes, see the [postgresql-k8s-bundle](https://github.com/canonical/postgresql-k8s-bundle).
 


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for 
* CharmHub Badge
* Release
* Tests
