### PR TITLE
Use poetry package-mode=false

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,7 @@
 # See LICENSE file for licensing details.
 
 [tool.poetry]
-name = "postgresql-bundle"
-version = "0.0.1-dev.0"
-description = ""
-authors = []
-license = "Apache-2.0"
-readme = "README.md"
-homepage = "https://charmhub.io/postgresql-bundle"
-repository = "https://github.com/canonical/postgresql-bundle"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10.6"


### PR DESCRIPTION
Added in poetry 1.8

(metadata unused since charm is not a Python package)
