### PR TITLE
Fix PG bundle: use grafana-agent trak 1 + test 3 units cluster + rename/realign apps

### DIFF
--- a/releases/latest/postgresql-bundle.yaml
+++ b/releases/latest/postgresql-bundle.yaml
@@ -1,64 +1,74 @@
 applications:
-  data-integrator:
+  app-ext:
     channel: latest/edge
     charm: data-integrator
     constraints: arch=amd64
     num_units: 1
     revision: 160
-    series: jammy
+    options:
+      database-name: mydb
     to:
-    - '3'
-  grafana-agent:
+    - '4'
+  app-ext-admin:
+    channel: latest/edge
+    charm: data-integrator
+    constraints: arch=amd64
+    num_units: 1
+    revision: 160
+    options:
+      database-name: mydb
+      extra-user-roles: admin
+    to:
+    - '4'
+  cos-agent-app-ext:
     channel: 1/edge
     charm: grafana-agent
-    revision: 469
-    series: jammy
-  landscape-client:
+    revision: 490
+  cos-agent-app-int:
+    channel: 1/edge
+    charm: grafana-agent
+    revision: 490
+  cos-agent-app-int-perf:
+    channel: 1/edge
+    charm: grafana-agent
+    revision: 490
+  cos-agent-db:
+    channel: 1/edge
+    charm: grafana-agent
+    revision: 490
+  cos-agent-lb-ext:
+    channel: 1/edge
+    charm: grafana-agent
+    revision: 490
+  cos-agent-lb-int:
+    channel: 1/edge
+    charm: grafana-agent
+    revision: 490
+  lp-client:
     channel: latest/edge
     charm: landscape-client
     config:
       ppa: ppa:landscape/self-hosted-beta
     revision: 72
-    series: jammy
-  pgbouncer-data-integrator:
+  lb-ext:
     channel: 1/edge
     charm: pgbouncer
     revision: 762
-    series: jammy
-  pgbouncer-test-app:
+  lb-int:
     channel: 1/edge
     charm: pgbouncer
     revision: 762
-    series: jammy
-  postgresql:
+  db:
     channel: 14/edge
     charm: postgresql
     constraints: arch=amd64
-    num_units: 2
+    num_units: 3
     revision: 780
-    series: jammy
     to:
     - '0'
     - '1'
-  postgresql-test-app:
-    channel: latest/edge
-    charm: postgresql-test-app
-    constraints: arch=amd64
-    num_units: 1
-    revision: 383
-    series: jammy
-    to:
-    - '5'
-  s3-integrator:
-    channel: latest/edge
-    charm: s3-integrator
-    constraints: arch=amd64
-    num_units: 1
-    revision: 155
-    series: jammy
-    to:
-    - '4'
-  self-signed-certificates:
+    - '2'
+  tls:
     channel: latest/edge
     charm: self-signed-certificates
     constraints: arch=amd64
@@ -66,96 +76,94 @@ applications:
     options:
       ca-common-name: postgresql_bundle_ca
     revision: 304
-    series: jammy
     to:
-    - '2'
-  sysbench:
+    - '3'
+  app-int:
+    channel: latest/edge
+    charm: postgresql-test-app
+    constraints: arch=amd64
+    num_units: 1
+    revision: 383
+    to:
+    - '4'
+  s3:
+    channel: latest/edge
+    charm: s3-integrator
+    constraints: arch=amd64
+    num_units: 1
+    revision: 155
+    to:
+    - '4'
+  app-int-perf:
     channel: latest/edge
     charm: sysbench
     constraints: arch=amd64
     num_units: 1
     revision: 187
-    series: jammy
     to:
-    - '6'
-  ubuntu-advantage:
+    - '4'
+  ubuntu-pro:
     channel: latest/edge
     charm: ubuntu-advantage
     revision: 137
-    series: jammy
+description: Charmed PostgreSQL bundle
+issues: https://github.com/canonical/postgresql-bundle/issues
 machines:
   '0':
     constraints: arch=amd64
-    series: jammy
+    base: ubuntu@22.04
   '1':
     constraints: arch=amd64
-    series: jammy
+    base: ubuntu@22.04
   '2':
     constraints: arch=amd64
-    series: jammy
+    base: ubuntu@22.04
   '3':
     constraints: arch=amd64
-    series: jammy
+    base: ubuntu@22.04
   '4':
     constraints: arch=amd64
-    series: jammy
-  '5':
-    constraints: arch=amd64
-    series: jammy
-  '6':
-    constraints: arch=amd64
-    series: jammy
+    base: ubuntu@22.04
 name: postgresql-bundle
 relations:
-- - pgbouncer-data-integrator:backend-database
-  - postgresql:database
-- - pgbouncer-test-app:backend-database
-  - postgresql:database
-- - pgbouncer-data-integrator:database
-  - data-integrator:postgresql
-- - pgbouncer-test-app:database
-  - postgresql-test-app:database
-- - postgresql:certificates
-  - self-signed-certificates:certificates
-- - pgbouncer-data-integrator:certificates
-  - self-signed-certificates:certificates
-- - postgresql:s3-parameters
-  - s3-integrator:s3-credentials
-- - postgresql:database
-  - sysbench:postgresql
-- - data-integrator:juju-info
-  - grafana-agent:juju-info
-- - postgresql-test-app:juju-info
-  - grafana-agent:juju-info
-- - postgresql:cos-agent
-  - grafana-agent:cos-agent
-- - pgbouncer-data-integrator:cos-agent
-  - grafana-agent:cos-agent
-- - pgbouncer-test-app:cos-agent
-  - grafana-agent:cos-agent
-- - landscape-client:container
-  - data-integrator:juju-info
-- - landscape-client:container
-  - postgresql:juju-info
-- - landscape-client:container
-  - postgresql-test-app:juju-info
-- - landscape-client:container
-  - sysbench:juju-info
-- - landscape-client:container
-  - s3-integrator:juju-info
-- - landscape-client:container
-  - self-signed-certificates:juju-info
-- - ubuntu-advantage:juju-info
-  - data-integrator:juju-info
-- - ubuntu-advantage:juju-info
-  - postgresql:juju-info
-- - ubuntu-advantage:juju-info
-  - postgresql-test-app:juju-info
-- - ubuntu-advantage:juju-info
-  - sysbench:juju-info
-- - ubuntu-advantage:juju-info
-  - s3-integrator:juju-info
-- - ubuntu-advantage:juju-info
-  - self-signed-certificates:juju-info
-series: jammy
+- - lb-ext:backend-database
+  - db:database
+- - lb-int:backend-database
+  - db:database
+- - lb-ext:database
+  - app-ext:postgresql
+- - db:database
+  - app-ext-admin:postgresql
+- - lb-int:database
+  - app-int:database
+- - db:certificates
+  - tls:certificates
+- - lb-ext:certificates
+  - tls:certificates
+- - db:s3-parameters
+  - s3:s3-credentials
+- - db:database
+  - app-int-perf:postgresql
+- - app-ext:juju-info
+  - cos-agent-app-ext:juju-info
+- - app-int:juju-info
+  - cos-agent-app-int:juju-info
+- - app-int-perf:juju-info
+  - cos-agent-app-int-perf:juju-info
+- - db:cos-agent
+  - cos-agent-db:cos-agent
+- - lb-ext:cos-agent
+  - cos-agent-lb-ext:cos-agent
+- - cos-agent-lb-ext:juju-info
+  - app-ext:juju-info
+- - cos-agent-lb-int:juju-info
+  - app-int:juju-info
+- - lb-int:cos-agent
+  - cos-agent-lb-int:cos-agent
+- - lp-client:container
+  - db:juju-info
+- - ubuntu-pro:juju-info
+  - db:juju-info
+base: ubuntu@22.04
+source: https://github.com/canonical/postgresql-bundle
 type: bundle

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -9,21 +9,28 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-TEST_APP_NAME = "postgresql-test-app"
+POSTGRES_NAME = "db"
+TEST_APP_NAME = "app-int"
 ACTIVE_APPS = [
-    "pgbouncer-data-integrator",
-    "pgbouncer-test-app",
-    "postgresql",
+    "app-ext",
+    "app-ext-admin",
+    "lb-ext",
     TEST_APP_NAME,
-    "self-signed-certificates",
-    "sysbench",
+    "app-int-perf",
+    "lb-int",
+    POSTGRES_NAME,
+    "tls",
 ]
 BLOCKED_APPS = [
-    "data-integrator",
-    "grafana-agent",
-    "landscape-client",
-    "s3-integrator",
-    "ubuntu-advantage",
+    "cos-agent-app-ext",
+    "cos-agent-app-int",
+    "cos-agent-app-int-perf",
+    "cos-agent-db",
+    "cos-agent-lb-ext",
+    "cos-agent-lb-int",
+    "lp-client",
+    "s3",
+    "ubuntu-pro",
 ]
 
 
@@ -32,7 +39,7 @@ BLOCKED_APPS = [
 async def test_setup(ops_test: OpsTest):
     async with ops_test.fast_forward():
         await ops_test.model.deploy("./releases/latest/postgresql-bundle.yaml")
-        await ops_test.model.applications["postgresql"].set_config({"profile": "testing"})
+        await ops_test.model.applications[POSTGRES_NAME].set_config({"profile": "testing"})
         await ops_test.model.wait_for_idle(
             apps=ACTIVE_APPS,
             status="active",


### PR DESCRIPTION
Also add more components to test and name them logically.

## Issue

The COS charms (grafana-agent) has renamed tracks (latest=>1) which makes bundle unusable.
The current bundle deploy 2 units PG cluster while we recommend 3+.

## Solution

Update grafana-agent to use track 1.
Deploy 3 units cluster + name components on the deivery purpose (and not by charm name):
 * *-ext - components for external DB access
 * *-int - internal (juju model) db access
Also, while here:
*  add database-name to data-integrator and deploy it second time with extra-user-roles=admin.
* minimize LXD containers count usage to speedup the test.

The final bundle:
```
Model       Controller  Cloud/Region         Version  SLA          Timestamp
testbundle  lxd         localhost/localhost  3.6.7    unsupported  14:09:04+02:00

App                     Version  Status   Scale  Charm                     Channel      Rev  Exposed  Message
app-ext                          active       1  data-integrator           latest/edge  160  no       
app-ext-admin                    active       1  data-integrator           latest/edge  160  no       
app-int                          active       1  postgresql-test-app       latest/edge  383  no       received database credentials of the first database
app-int-perf                     active       1  sysbench                  latest/edge  187  no       
cos-agent-app-ext                blocked      1  grafana-agent             1/edge       469  no       Missing ['grafana-cloud-config']|['logging-consumer']|['send-remote-write'] for juju-info
cos-agent-app-int                blocked      1  grafana-agent             1/edge       469  no       Missing ['grafana-cloud-config']|['logging-consumer']|['send-remote-write'] for juju-info
cos-agent-app-int-perf           blocked      1  grafana-agent             1/edge       469  no       Missing ['grafana-cloud-config']|['logging-consumer']|['send-remote-write'] for juju-info
cos-agent-db                     blocked      3  grafana-agent             1/edge       469  no       Missing ['grafana-cloud-config']|['grafana-dashboards-provider']|['logging-consumer']|['send-remote-write'] for cos-a...
cos-agent-lb-ext                 blocked      1  grafana-agent             1/edge       469  no       Missing ['grafana-cloud-config']|['grafana-dashboards-provider']|['logging-consumer']|['send-remote-write'] for cos-a...
cos-agent-lb-int                 blocked      1  grafana-agent             1/edge       469  no       Missing ['grafana-cloud-config']|['grafana-dashboards-provider']|['logging-consumer']|['send-remote-write'] for cos-a...
db                      14.17    active       3  postgresql                14/edge      780  no       Primary
lb-ext                  1.21.0   active       1  pgbouncer                 1/edge       762  no       
lb-int                  1.21.0   active       1  pgbouncer                 1/edge       762  no       
lp-client                        blocked      3  landscape-client          latest/edge   72  no       Registration failed!
s3                               blocked      1  s3-integrator             latest/edge  155  no       Missing parameters: ['access-key', 'secret-key']
tls                              active       1  self-signed-certificates  1/edge       304  no       
ubuntu-pro                       blocked      3  ubuntu-advantage          latest/edge  137  no       No token configured

Unit                         Workload  Agent      Machine  Public address  Ports     Message
app-ext-admin/0*             active    idle       4        10.176.3.56               
app-ext/0*                   active    idle       4        10.176.3.56               
  cos-agent-app-ext/0*       blocked   idle                10.176.3.56               Missing ['grafana-cloud-config']|['logging-consumer']|['send-remote-write'] for juju-info
  cos-agent-lb-ext/0*        blocked   idle                10.176.3.56               Missing ['grafana-cloud-config']|['grafana-dashboards-provider']|['logging-consumer']|['send-remote-write'] for cos-a...
  lb-ext/0*                  active    idle                10.176.3.56     6432/tcp
app-int-perf/0*              active    idle       4        10.176.3.56               
  cos-agent-app-int-perf/0*  blocked   idle                10.176.3.56               Missing ['grafana-cloud-config']|['logging-consumer']|['send-remote-write'] for juju-info
app-int/0*                   active    idle       4        10.176.3.56               received database credentials of the first database
  cos-agent-app-int/0*       blocked   idle                10.176.3.56               Missing ['grafana-cloud-config']|['logging-consumer']|['send-remote-write'] for juju-info
  cos-agent-lb-int/0*        blocked   idle                10.176.3.56               Missing ['grafana-cloud-config']|['grafana-dashboards-provider']|['logging-consumer']|['send-remote-write'] for cos-a...
  lb-int/0*                  active    idle                10.176.3.56               
db/0*                        active    idle       0        10.176.3.38     5432/tcp  Primary
  cos-agent-db/0*            blocked   idle                10.176.3.38               Missing ['grafana-cloud-config']|['grafana-dashboards-provider']|['logging-consumer']|['send-remote-write'] for cos-a...
  lp-client/0*               blocked   idle                10.176.3.38               Registration failed!
  ubuntu-pro/0*              blocked   idle                10.176.3.38               No token configured
db/1                         waiting   idle       1        10.176.3.59     5432/tcp  
  cos-agent-db/1             blocked   idle                10.176.3.59               Missing ['grafana-cloud-config']|['grafana-dashboards-provider']|['logging-consumer']|['send-remote-write'] for cos-a...
  lp-client/1                blocked   idle                10.176.3.59               Registration failed!
  ubuntu-pro/1               blocked   idle                10.176.3.59               No token configured
db/2                         active    idle       2        10.176.3.135    5432/tcp  
  cos-agent-db/2             blocked   idle                10.176.3.135              Missing ['grafana-cloud-config']|['grafana-dashboards-provider']|['logging-consumer']|['send-remote-write'] for cos-a...
  lp-client/2                blocked   idle                10.176.3.135              Registration failed!
  ubuntu-pro/2               blocked   idle                10.176.3.135              No token configured
s3/0*                        blocked   idle       4        10.176.3.56               Missing parameters: ['access-key', 'secret-key']
tls/0*                       active    idle       3        10.176.3.124              

Machine  State    Address       Inst id        Base          AZ  Message
0        started  10.176.3.38   juju-8de4ec-0  ubuntu@22.04      Running
1        started  10.176.3.59   juju-8de4ec-1  ubuntu@22.04      Running
2        started  10.176.3.135  juju-8de4ec-2  ubuntu@22.04      Running
3        started  10.176.3.124  juju-8de4ec-3  ubuntu@22.04      Running
4        started  10.176.3.56   juju-8de4ec-4  ubuntu@22.04      Running
```

## Possible followup:
 * add COS + relations to grafana-agents
 *  add tokens for ubuntu-pro & landscape-clients
 *  add S3 for backups + bucket/secrets
