### PR TITLE
[DPE-7816] Fix grafana-agent channel

### DIFF
--- a/releases/latest/postgresql-bundle.yaml
+++ b/releases/latest/postgresql-bundle.yaml
@@ -9,7 +9,7 @@ applications:
     to:
     - '3'
   grafana-agent:
-    channel: latest/edge
+    channel: 1/edge
     charm: grafana-agent
     revision: 469
     series: jammy


### PR DESCRIPTION
## Issue
The `latest/edge` track is not available anymore for the `grafana-agent` charm.

```sh
~ juju info grafana-agent
name: grafana-agent
...
channels: |
  1/stable:     84a7251  2025-07-08  (493)  13MB  arm64  ubuntu@24.04
  1/candidate:  84a7251  2025-06-26  (493)  13MB  arm64  ubuntu@24.04
  1/beta:       84a7251  2025-06-10  (493)  13MB  arm64  ubuntu@24.04
  1/edge:       84a7251  2025-05-14  (493)  13MB  arm64  ubuntu@24.04
  2/stable:     –
  2/candidate:  –
  2/beta:       –
  2/edge:       d012685  2025-06-25  (559)  13MB  arm64  ubuntu@24.04
```

## Solution
Update the track to `1/edge`.