### PR TITLE
[MISC] Downgrade charmcraft to reenable publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
-        run: sudo snap install charmcraft --classic
+        run: sudo snap install charmcraft --classic --channel=3.x/stable
       - name: Pack and publish bundle
         run: |
           set -ex


### PR DESCRIPTION
## Issue
Bundle packing was removed in charmcraft 4: https://github.com/canonical/charmcraft/pull/2320

## Solution
Downgrade to charmcraft 3 to be able to publish the bundle