### PR TITLE
Add zizmor and update dpw to v48

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,28 @@ on:
   workflow_call:
 
 jobs:
+  lint-workflows:
+    name: Lint .github/workflows/
+    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v48.0.4
+    permissions:
+      contents: read
+
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v42.0.1
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install tox & poetry
+        run: |
+          pipx install tox
+          pipx install poetry
+      - name: tox run -e lint
+        run: tox run -e lint
+    permissions: {}
 
   integration-test:
     name: Integration test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,17 +8,24 @@ on:
 jobs:
   integration-test:
     uses: ./.github/workflows/ci.yaml
+    permissions:
+      contents: read
 
   publish-bundle:
     name: Publish bundle
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
     needs:
       - integration-test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    environment:
+      name: edge
+      deployment: true
     env:
-      CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN_EDGE }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: sudo snap install charmcraft --classic --channel=3.x/stable
       - name: Pack and publish bundle
@@ -35,4 +42,4 @@ jobs:
           charmcraft upload ./*.zip
           REVISION=$(charmcraft revisions postgresql-bundle 2>&1 | awk 'NR==2 {print $1}')
           charmcraft release postgresql-bundle --revision "$REVISION" --channel=14/edge
-
+    permissions: {}

--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -9,9 +9,13 @@ on:
 jobs:
   update-bundle:
     name: Update bundle
-    uses: canonical/data-platform-workflows/.github/workflows/_update_bundle.yaml@v42.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/_update_bundle.yaml@v48.0.4
     with:
       path-to-bundle-file: releases/latest/postgresql-bundle.yaml
       reviewers: canonical/data-postgresql
     secrets:
-      token: ${{ secrets.PAT }}
+      token: ${{ secrets.CREATE_PR_APP_TOKEN }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: write  # Needed to push branch
+      pull-requests: write  # Needed to create PR

--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -14,7 +14,7 @@ jobs:
       path-to-bundle-file: releases/latest/postgresql-bundle.yaml
       reviewers: canonical/data-postgresql
     secrets:
-      token: ${{ secrets.CREATE_PR_APP_TOKEN }}
+      token: ${{ secrets.CREATE_PR_PAT }}
     permissions:
       actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to push branch

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,31 @@
+rules:
+  # Allowlist trusted actions
+  forbidden-uses:
+    config:
+      # Actions in this list have remote code execution in our workflows. Even if the workflow has
+      # limited permissions, those can be escaped. See https://github.com/AdnaneKhan/Cacheract and
+      # "But Wait, There’s More" section of
+      # https://www.praetorian.com/blog/codeqleaked-public-secrets-exposure-leads-to-supply-chain-attack-on-github-codeql/
+      # In general, this list should be limited to organizations that we trust to have a baseline
+      # level of operational security. Avoid adding actions that could be replaced with a few lines
+      # of bash.
+      allow:  # Get approval from your manager before adding actions to this list.
+        - canonical/*
+        - actions/*
+        - docker/login-action
+        - tiobe/tics-github-action
+  # Pinning actions to a commit SHA has a security tradeoff—pinned actions cannot be later
+  # compromised, but they also cannot be security patched.
+  # Above (in `forbidden-uses`), we restrict actions usage to organizations that we trust to have
+  # a baseline level of operational security.
+  # Our actions usage involves several long-term support branches and reusable workflows (which
+  # themselves use actions). For our threat model, we believe it is safer to limit actions usage to
+  # organizations we trust and immediately receive security patching across our many branches than
+  # it is to pin actions to a commit SHA.
+  unpinned-uses:
+    config:
+      policies:
+        canonical/*: ref-pin
+        actions/*: ref-pin
+        docker/login-action: ref-pin
+        tiobe/tics-github-action: ref-pin


### PR DESCRIPTION
https://discourse.canonical.com/t/security-update-action-requested/7120

After this PR is merged, the following secret actions will be required:
- Revoke and delete these secrets:
  ```
  CHARMHUB_TOKEN
  PAT
  ```
- Create these secrets (new credentials) for the `update-bundle` environment (do **not** add as repository secrets)
  ```
  CREATE_PR_PAT
  ```
    - Limit scope to permissions needed: https://github.com/canonical/data-platform-workflows/blob/3818c52ed6aeea4c357a002e749bebd87f17f866/.github/workflows/_update_bundle.yaml#L22-L25
- Create these secrets (new credentials) for the `edge` environment (do **not** add as repository secrets)
  ```
  CHARMHUB_TOKEN_EDGE
  ```
    - Will need to be regenerated after candid migration. (Unlike charms, where we are skipping CHARMHUB_TOKEN rotation for now, think we should rotate now so that we don't forget [since this doesn't use reusable workflow]. Alternatively, we could wait to merge this PR until after candid migration)